### PR TITLE
Stick to visible content

### DIFF
--- a/lib/sticky_headers/widget.dart
+++ b/lib/sticky_headers/widget.dart
@@ -34,6 +34,7 @@ class StickyHeader extends MultiChildRenderObjectWidget {
     @required this.header,
     @required this.content,
     this.overlapHeaders: false,
+    this.stickToVisibleContent: false,
     this.callback,
   }) : super(
           key: key,
@@ -50,6 +51,9 @@ class StickyHeader extends MultiChildRenderObjectWidget {
   /// If true, the header will overlap the Content.
   final bool overlapHeaders;
 
+  /// If true, the header starts scrolling once the bottom of the content is visible.
+  final bool stickToVisibleContent;
+
   /// Optional callback with stickyness value. If you think you need this, then you might want to
   /// consider using [StickyHeaderBuilder] instead.
   final RenderStickyHeaderCallback callback;
@@ -62,6 +66,7 @@ class StickyHeader extends MultiChildRenderObjectWidget {
       scrollable: scrollable,
       callback: this.callback,
       overlapHeaders: this.overlapHeaders,
+      stickToVisibleContent: this.stickToVisibleContent,
     );
   }
 
@@ -70,7 +75,8 @@ class StickyHeader extends MultiChildRenderObjectWidget {
     renderObject
       ..scrollable = Scrollable.of(context)
       ..callback = this.callback
-      ..overlapHeaders = this.overlapHeaders;
+      ..overlapHeaders = this.overlapHeaders
+      ..stickToVisibleContent = this.stickToVisibleContent;
   }
 }
 
@@ -88,6 +94,7 @@ class StickyHeaderBuilder extends StatefulWidget {
     @required this.builder,
     this.content,
     this.overlapHeaders: false,
+    this.stickToVisibleContent: false,
   }) : super(key: key);
 
   /// Called when the sticky amount changes for the header.
@@ -100,6 +107,9 @@ class StickyHeaderBuilder extends StatefulWidget {
   /// If true, the header will overlap the Content.
   final bool overlapHeaders;
 
+  /// If true, the header starts scrolling once the bottom of the content is visible.
+  final bool stickToVisibleContent;
+
   @override
   _StickyHeaderBuilderState createState() => new _StickyHeaderBuilderState();
 }
@@ -111,6 +121,7 @@ class _StickyHeaderBuilderState extends State<StickyHeaderBuilder> {
   Widget build(BuildContext context) {
     return new StickyHeader(
       overlapHeaders: widget.overlapHeaders,
+      stickToVisibleContent: widget.stickToVisibleContent,
       header: new LayoutBuilder(
         builder: (context, _) => widget.builder(context, _stuckAmount ?? 0.0),
       ),


### PR DESCRIPTION
First things first, thank you very much for this package. It's very useful functionally and I also found the code a pleasure to read in the sense that it's simple to understand despite the fact that I'm not at all familiar with these kinds of widgets and extending `RenderBox`. Well commented and intelligently structured.

---

This PR adds an option to start scrolling the header once the bottom of the body is visible rather than remaining sticky until the header no longer fits in the visible content. I made this tweak for my own purposes but perhaps it can be useful to others, if not at least an example for anyone requesting similar behaviour. I found the naming tricky so I'm open to suggestions on that!

I use sticky headers to show an image that is relevant to just a few rows that follow it (some rows don't have an associated image). My motivation for using sticky headers is to make sure the image is completely visible for all of the associated rows and since the image takes up quite a bit of visual real estate I want it to scroll out of the way as soon as the last associated list item is completely visible.

Here's the listview:

```dart
    ListView.builder(
      itemBuilder: (context, i) {
        if (routeGroups[i] is TopoGroup) {
          TopoGroup topoGroup = routeGroups[i];

          return StickyHeader(
            stickToVisibleContent: true,
            header: Container(
              height: widgetSize.height / 3,
              child: GalleryImage(topoGroup.topoList.first, tappedRouteNum),
            ),
            content: Column(
              children: topoGroup.routes
                  .map<Widget>((route) => _tileFor(route, hasTopo: true))
                  .toList(),
            ),
          );
        } else {
          SectorRoute route = routeGroups[i];

          return _tileFor(route);
        }
      },
      itemCount: routeGroups.length,
    );
```